### PR TITLE
include padding bits for mic calculation

### DIFF
--- a/schc_fragment_ruledb.py
+++ b/schc_fragment_ruledb.py
@@ -23,6 +23,7 @@ class schc_runtime_fragment_rule:
         self.bitmap_size = (2**self.fcn_size) - 1
         self.bitmap_all_1 = (2**self.bitmap_size)-1
         self.cbit_size = 0 if self.mode == SCHC_MODE.NO_ACK else 1
+        self.pad_bits_size = 0
         #
         # sanity check the base values
         if self.rid > (2**self.C.rid_size)-1:

--- a/test-frag-client-udp.py
+++ b/test-frag-client-udp.py
@@ -33,7 +33,7 @@ def schc_sender(msg):
     
     # prepare fragmenting
     factory = sfs.fragment_factory(frr, logger=debug_print)
-    factory.setbuf(msg, dtag=opt.dtag)
+    factory.setbuf(msg, dtag=opt.dtag, l2_size=opt.l2_size)
     
     # main loop
     debug_print(1, "L2 payload size: %s" % opt.l2_size)


### PR DESCRIPTION
this PR includes the function to calculate the padding bits that shall be added to the last fragment.
as suggested by @dbarthel-ol  over this [etherpad](https://pad.inria.fr/p/np_6yuK052j9601O7Hr), extra-bits '0' is included to the srcbuf to be considered for MIC calculation. 
TODO: remove these extra-bits while transmitting the last fragment.